### PR TITLE
Fix incorrect log rotation

### DIFF
--- a/unifi.logrotate
+++ b/unifi.logrotate
@@ -1,17 +1,7 @@
-/var/log/unifi/server.log* {
+/var/log/unifi/server.log {
   monthly
   maxage 365
   compress
   missingok
   copytruncate
-}
-
-/var/log/unifi/mongod.log {
-  monthly
-  maxage 365
-  compress
-  missingok
-  lastaction
-    killall -SIGUSR1 mongod
-  endscript
 }


### PR DESCRIPTION
Hello,

there are two problems with log rotation at the moment.

First, the match statement of `server.log` includes already rotated files, this is creating more and more rotated copies of the same content after some time:

```
-rw-r--r--. 1 unifi unifi     0  1. úno 03.44 server.log-20200801.gz-20200901.gz
-rw-r--r--. 1 unifi unifi     0  1. úno 03.44 server.log-20200801.gz-20200901.gz-20201001.gz-20201101.gz
-rw-r--r--. 1 unifi unifi     0  1. úno 03.44 server.log-20200801.gz-20200901.gz-20201001.gz-20201101.gz-20201201.gz
-rw-r--r--. 1 unifi unifi     0  1. úno 03.44 server.log-20200801.gz-20200901.gz-20201001.gz-20201101.gz-20201201.gz-20210101.gz
-rw-r--r--. 1 unifi unifi  5720 28. čec  2020 server.log-20200801.gz-20200901.gz-20201001.gz-20201101.gz-20201201.gz-20210101.gz-20210201.gz
-rw-r--r--. 1 unifi unifi    20  1. led 03.50 server.log-20200801.gz-20200901.gz-20201001.gz-20201101.gz-20201201.gz-20210201.gz
-rw-r--r--. 1 unifi unifi     0  1. úno 03.44 server.log-20200801.gz-20200901.gz-20201001.gz-20201101.gz-20210101.gz
-rw-r--r--. 1 unifi unifi    33  1. pro 03.13 server.log-20200801.gz-20200901.gz-20201001.gz-20201101.gz-20210101.gz-20210201.gz
-rw-r--r--. 1 unifi unifi    20  1. led 03.50 server.log-20200801.gz-20200901.gz-20201001.gz-20201101.gz-20210201.gz
-rw-r--r--. 1 unifi unifi     0  1. úno 03.44 server.log-20200801.gz-20200901.gz-20201001.gz-20201201.gz
-rw-r--r--. 1 unifi unifi     0  1. úno 03.44 server.log-20200801.gz-20200901.gz-20201001.gz-20201201.gz-20210101.gz
-rw-r--r--. 1 unifi unifi    55  1. lis 03.12 server.log-20200801.gz-20200901.gz-20201001.gz-20201201.gz-20210101.gz-20210201.gz
```

Second, on my system with default configuration, MongoDB uses its own log rotation:
https://docs.mongodb.com/manual/tutorial/rotate-log-files/

```
-rw-------. 1 unifi unifi 61245  7. úno 11.35 mongod.log
-rw-------. 1 unifi unifi     0  8. úno  2020 mongod.log.2020-02-08T17-37-01
-rw-------. 1 unifi unifi     0  1. bře  2020 mongod.log.2020-03-01T02-29-01
-rw-------. 1 unifi unifi     0  1. dub  2020 mongod.log.2020-04-01T01-36-01
-rw-------. 1 unifi unifi     0  1. kvě  2020 mongod.log.2020-05-01T01-45-01
-rw-------. 1 unifi unifi     0  1. čen  2020 mongod.log.2020-06-01T01-38-01
-rw-------. 1 unifi unifi     0  1. čec  2020 mongod.log.2020-07-01T01-33-01
-rw-------. 1 unifi unifi     0  1. srp  2020 mongod.log.2020-08-01T01-49-01
-rw-------. 1 unifi unifi     0  1. zář 03.24 mongod.log.2020-09-01T01-24-01
-rw-------. 1 unifi unifi     0  1. říj 03.07 mongod.log.2020-10-01T01-07-03
```

There is no need to rotate anything and send any signal, this should work out of box.

This patch fixes both problems, cheers!